### PR TITLE
Add correct install steps for *nix

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,13 +1,10 @@
 *nix
 ----
-1. Change PREFIX in qmpdclient.pro if /usr/local is not desirable
-2. qmake
-3. make (gmake on some platforms)
-4. su -c "make install"
-
-Eventual extra datafiles go into the following locations:
-/usr/local/share/QMPDClient/[styles|iconsets|translations]	(Substitute /usr/local for appropriate prefix)
-or $HOME/.local/share/QMPDClient/[styles|iconsets|translations]
+1. mkdir -p build
+2. cd build
+3. cmake ..
+4. cmake --build .
+4. sudo cmake --install .
 
 
 Win32


### PR DESCRIPTION
I tried the previous steps, but didn't work, so went to the AUR package to extract what it did (I'm not on AUR, I'm on Kubuntu 20.04), tested it, and it worked flawlessly. So, I thought updating the docs was a good idea :)  
I can expect the Win steps to be broken too, but can't test, so ¯\_(ツ)_/¯

Please make sure it's correct for other platform, if possible though.